### PR TITLE
Check for try-error using inherits

### DIFF
--- a/Darts_BHT/Darts_BHT/Darts/R/darts.r
+++ b/Darts_BHT/Darts_BHT/Darts/R/darts.r
@@ -241,7 +241,7 @@ myLaplace = function(log_func, gr_func, init_value, data, method='Nelder-Mead', 
 			lower=c(0.001, -0.999, rep(0.001,length(init_value)-2)),
 			upper=c(0.999, 0.999, rep(0.999,length(init_value)-2))
 			), silent=T)
-		if(class(res)=="try-error" || sum( abs(res$par - init_value ))<0.001 ) {
+		if(inherits(res, "try-error") || sum( abs(res$par - init_value ))<0.001 ) {
 			method='Nel'
 		} else {
 			res$hessian = estim_hess(res$par, gr_func,data, ...)
@@ -267,7 +267,7 @@ myLaplace = function(log_func, gr_func, init_value, data, method='Nelder-Mead', 
 	hess[which(is.na(hess),arr.ind=T)]=0
 	if(n_par>1)	lap_sigma = try(solve(-hess), silent=T)
 	if(n_par==1) lap_sigma = -1/res$hessian
-	if(class(lap_sigma)=="try-error")
+	if(inherits(lap_sigma, "try-error"))
 	{
 		return(list(MAP=theta_hat, hess=hess, integral=NA))
 		#sigma = ginv(-hess)


### PR DESCRIPTION
The help message from ?try says to use inherits because:
> if there is no error, the result might (now or in future) have a class of length > 1

The release notes for R 4.0.0 include:
> matrix objects now also inherit from class "array", so e.g.,
  class(diag(1)) is c("matrix", "array").  This invalidates code
  incorrectly assuming that class(matrix_obj)) has length one.

This change was necessary since lap_sigma is a matrix